### PR TITLE
fix: show business name on Home Screen instead of generic title

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -107,6 +107,9 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 
   return {
+    title: {
+      absolute: businessName,
+    },
     applicationName: businessName,
     manifest: `/api/pwa/manifest?${params.toString()}`,
     appleWebApp: {


### PR DESCRIPTION
## Summary
- iOS "Add to Home Screen" mostraba "Dashboard | BarberApp" en vez del nombre del negocio
- Se agregó `title: { absolute: businessName }` en `generateMetadata()` del dashboard layout para sobreescribir el template `%s | BarberApp` del root layout
- Mismo patrón que ya se usa en el booking layout público (`src/app/(public)/reservar/[slug]/layout.tsx`)

## Test plan
- [ ] Abrir dashboard en iOS Safari → Compartir → Agregar a Inicio → verificar que muestra el nombre del negocio
- [ ] Verificar que el tab del browser también muestra el nombre del negocio

🤖 Generated with [Claude Code](https://claude.ai/claude-code)